### PR TITLE
[OMID-54] Fix leak of CommitTable.Client objects in Compactor Coproce…

### DIFF
--- a/hbase-coprocessor/src/main/java/org/apache/hadoop/hbase/regionserver/CompactorScanner.java
+++ b/hbase-coprocessor/src/main/java/org/apache/hadoop/hbase/regionserver/CompactorScanner.java
@@ -54,7 +54,6 @@ public class CompactorScanner implements InternalScanner {
     private static final Logger LOG = LoggerFactory.getLogger(CompactorScanner.class);
     private final InternalScanner internalScanner;
     private final CommitTable.Client commitTableClient;
-    private final Queue<CommitTable.Client> commitTableClientQueue;
     private final boolean isMajorCompaction;
     private final boolean retainNonTransactionallyDeletedCells;
     private final long lowWatermark;
@@ -67,12 +66,10 @@ public class CompactorScanner implements InternalScanner {
     public CompactorScanner(ObserverContext<RegionCoprocessorEnvironment> e,
                             InternalScanner internalScanner,
                             Client commitTableClient,
-                            Queue<CommitTable.Client> commitTableClientQueue,
                             boolean isMajorCompaction,
                             boolean preserveNonTransactionallyDeletedCells) throws IOException {
         this.internalScanner = internalScanner;
         this.commitTableClient = commitTableClient;
-        this.commitTableClientQueue = commitTableClientQueue;
         this.isMajorCompaction = isMajorCompaction;
         this.retainNonTransactionallyDeletedCells = preserveNonTransactionallyDeletedCells;
         this.lowWatermark = getLowWatermarkFromCommitTable();
@@ -182,7 +179,7 @@ public class CompactorScanner implements InternalScanner {
     @Override
     public void close() throws IOException {
         internalScanner.close();
-        commitTableClientQueue.add(commitTableClient);
+        commitTableClient.close(); // Ensure we free the resources that the HBase impl use (executor threads, etc...)
     }
 
     // ----------------------------------------------------------------------------------------------------------------

--- a/hbase-coprocessor/src/test/java/org/apache/omid/transaction/TestCompactorScanner.java
+++ b/hbase-coprocessor/src/test/java/org/apache/omid/transaction/TestCompactorScanner.java
@@ -65,7 +65,6 @@ public class TestCompactorScanner {
         InternalScanner internalScanner = mock(InternalScanner.class);
         CommitTable.Client ctClient = mock(CommitTable.Client.class);
         @SuppressWarnings("unchecked")
-        Queue<Client> queue = mock(Queue.class);
         RegionCoprocessorEnvironment rce = mock(RegionCoprocessorEnvironment.class);
         HRegion hRegion = mock(HRegion.class);
         HRegionInfo hRegionInfo = mock(HRegionInfo.class);
@@ -82,7 +81,6 @@ public class TestCompactorScanner {
         try (CompactorScanner scanner = spy(new CompactorScanner(ctx,
                 internalScanner,
                 ctClient,
-                queue,
                 false,
                 retainOption))) {
 


### PR DESCRIPTION
…ssor

Now, each time preCompact() is called, a new CommitTable.Client object is created.
A factory for CommitTable clients has been created in order to allow to inject mocked
instances in Coprocessor tests.

Change-Id: If32f3b09b68c61f4f6d573feeb89080b04f1bfe4