### PR TITLE
[OMID-64] Fix location of protobuf tgz in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - git config --global user.name "Omid CI"
   # Install protobuf to genearte TSO client-server protocol in each compilation
   - cd ..
-  - wget https://protobuf.googlecode.com/files/protobuf-2.5.0.tar.gz
+  - wget https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.gz
   - tar -xzvf protobuf-2.5.0.tar.gz
   - cd protobuf-2.5.0 && ./configure --prefix=/usr && make && sudo make install
   - cd ../incubator-omid


### PR DESCRIPTION
Location has changed to
https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.gz

Change-Id: Icd7740ff23bf17142fb47bdc530178b0292b3a05