### PR TITLE
[OMID-74] Efficient column family deletion in Row level conflict analysis

### DIFF
--- a/hbase-client/src/main/java/org/apache/omid/transaction/HBaseTransactionManager.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/HBaseTransactionManager.java
@@ -31,6 +31,7 @@ import org.apache.omid.committable.hbase.HBaseCommitTable;
 import org.apache.omid.committable.hbase.HBaseCommitTableConfig;
 import org.apache.omid.tools.hbase.HBaseLogin;
 import org.apache.omid.tso.client.CellId;
+import org.apache.omid.tso.client.OmidClientConfiguration.ConflictDetectionLevel;
 import org.apache.omid.tso.client.TSOClient;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Result;
@@ -258,6 +259,10 @@ public class HBaseTransactionManager extends AbstractTransactionManager implemen
                     "The transaction object passed is not an instance of HBaseTransaction");
         }
 
+    }
+
+    public ConflictDetectionLevel getConflictDetectionLevel() {
+        return tsoClient.getConflictDetectionLevel();
     }
 
     static class CommitTimestampLocatorImpl implements CommitTimestampLocator {

--- a/hbase-client/src/test/java/org/apache/omid/transaction/TestColumnIterator.java
+++ b/hbase-client/src/test/java/org/apache/omid/transaction/TestColumnIterator.java
@@ -61,7 +61,7 @@ public class TestColumnIterator {
     public void testGroupingCellsByColumnFilteringShadowCells() {
 
         ImmutableList<Collection<Cell>> groupedColumnsWithoutShadowCells =
-                TTable.groupCellsByColumnFilteringShadowCells(cells);
+                TTable.groupCellsByColumnFilteringShadowCellsAndFamilyDeletion(cells);
         Log.info("Column Groups " + groupedColumnsWithoutShadowCells);
         assertEquals(groupedColumnsWithoutShadowCells.size(), 3, "Should be 3 column groups");
         int group1Counter = 0;

--- a/hbase-client/src/test/java/org/apache/omid/transaction/TestShadowCells.java
+++ b/hbase-client/src/test/java/org/apache/omid/transaction/TestShadowCells.java
@@ -20,10 +20,9 @@ package org.apache.omid.transaction;
 import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
 import com.google.common.util.concurrent.ListenableFuture;
+
 import org.apache.omid.committable.CommitTable;
-
 import org.apache.omid.metrics.NullMetricsProvider;
-
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.KeyValue;
@@ -45,7 +44,9 @@ import org.testng.ITestContext;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -345,7 +346,7 @@ public class TestShadowCells extends OmidTestBase {
                             return (List<KeyValue>) invocation.callRealMethod();
                         }
                     }).when(table).filterCellsForSnapshot(Matchers.<List<Cell>>any(),
-                            any(HBaseTransaction.class), anyInt());
+                            any(HBaseTransaction.class), anyInt(), Matchers.<Map<String, List<Cell>>>any());
 
                     TransactionManager tm = newTransactionManager(context);
                     if (hasShadowCell(row,

--- a/hbase-common/src/main/java/org/apache/omid/transaction/CellUtils.java
+++ b/hbase-common/src/main/java/org/apache/omid/transaction/CellUtils.java
@@ -49,6 +49,7 @@ public final class CellUtils {
     private static final Logger LOG = LoggerFactory.getLogger(CellUtils.class);
     static final byte[] SHADOW_CELL_SUFFIX = "\u0080".getBytes(Charsets.UTF_8); // Non printable char (128 ASCII)
     static byte[] DELETE_TOMBSTONE = Bytes.toBytes("__OMID_TOMBSTONE__");
+    public static final byte[] FAMILY_DELETE_QUALIFIER = new byte[0];
 
     /**
      * Utility interface to get rid of the dependency on HBase server package

--- a/transaction-client/src/main/java/org/apache/omid/tso/client/TSOClient.java
+++ b/transaction-client/src/main/java/org/apache/omid/tso/client/TSOClient.java
@@ -299,6 +299,14 @@ public class TSOClient implements TSOProtocol, NodeCacheListener {
         return epoch;
     }
 
+    /**
+     * Used for family deletion
+     * @return the conflict detection level.
+     */
+    public ConflictDetectionLevel getConflictDetectionLevel() {
+        return conflictDetectionLevel;
+    }
+
     // ----------------------------------------------------------------------------------------------------------------
     // NodeCacheListener interface
     // ----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The idea is to use a qualifier to denote that all the columns of a specific family were deleted.
Current implementation reads from HBase the entire family and then writes a tombstone to each one of its cells.
The new implementation does not need to perform the read and only writes the qualifier to denote that the family was deleted.
This is true only for Row level conflict detection since in Cell level we need to read the cells and add these to the write set.