### PR TITLE
[OMID-84] Today, all the writes done by a transaction are taking part…

### DIFF
--- a/hbase-client/src/main/java/org/apache/omid/transaction/HBaseTransaction.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/HBaseTransaction.java
@@ -31,25 +31,31 @@ import java.util.Set;
 public class HBaseTransaction extends AbstractTransaction<HBaseCellId> {
     private static final Logger LOG = LoggerFactory.getLogger(HBaseTransaction.class);
 
-    public HBaseTransaction(long transactionId, long epoch, Set<HBaseCellId> writeSet, AbstractTransactionManager tm) {
-        super(transactionId, epoch, writeSet, tm);
+    public HBaseTransaction(long transactionId, long epoch, Set<HBaseCellId> writeSet, Set<HBaseCellId> conflictFreeWriteSet, AbstractTransactionManager tm) {
+        super(transactionId, epoch, writeSet, conflictFreeWriteSet, tm);
     }
 
-    public HBaseTransaction(long transactionId, long readTimestamp, VisibilityLevel visibilityLevel, long epoch, Set<HBaseCellId> writeSet, AbstractTransactionManager tm) {
-        super(transactionId, readTimestamp, visibilityLevel, epoch, writeSet, tm);
+    public HBaseTransaction(long transactionId, long readTimestamp, VisibilityLevel visibilityLevel, long epoch, Set<HBaseCellId> writeSet, Set<HBaseCellId> conflictFreeWriteSet, AbstractTransactionManager tm) {
+        super(transactionId, readTimestamp, visibilityLevel, epoch, writeSet, conflictFreeWriteSet, tm);
     }
 
+    private void cleanCell(HBaseCellId cell) {
+        Delete delete = new Delete(cell.getRow());
+        delete.deleteColumn(cell.getFamily(), cell.getQualifier(), cell.getTimestamp());
+        try {
+            cell.getTable().delete(delete);
+        } catch (IOException e) {
+            LOG.warn("Failed cleanup cell {} for Tx {}. This issue has been ignored", cell, getTransactionId(), e);
+        }
+    }
     @Override
     public void cleanup() {
-        Set<HBaseCellId> writeSet = getWriteSet();
-        for (final HBaseCellId cell : writeSet) {
-            Delete delete = new Delete(cell.getRow());
-            delete.deleteColumn(cell.getFamily(), cell.getQualifier(), cell.getTimestamp());
-            try {
-                cell.getTable().delete(delete);
-            } catch (IOException e) {
-                LOG.warn("Failed cleanup cell {} for Tx {}. This issue has been ignored", cell, getTransactionId(), e);
-            }
+        for (final HBaseCellId cell : getWriteSet()) {
+            cleanCell(cell);
+        }
+
+        for (final HBaseCellId cell : getConflictFreeWriteSet()) {
+            cleanCell(cell);
         }
         try {
             flushTables();
@@ -77,6 +83,10 @@ public class HBaseTransaction extends AbstractTransaction<HBaseCellId> {
     private Set<HTableInterface> getWrittenTables() {
         HashSet<HBaseCellId> writeSet = (HashSet<HBaseCellId>) getWriteSet();
         Set<HTableInterface> tables = new HashSet<HTableInterface>();
+        for (HBaseCellId cell : writeSet) {
+            tables.add(cell.getTable());
+        }
+        writeSet = (HashSet<HBaseCellId>) getConflictFreeWriteSet();
         for (HBaseCellId cell : writeSet) {
             tables.add(cell.getTable());
         }

--- a/hbase-client/src/main/java/org/apache/omid/transaction/HBaseTransaction.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/HBaseTransaction.java
@@ -39,7 +39,7 @@ public class HBaseTransaction extends AbstractTransaction<HBaseCellId> {
         super(transactionId, readTimestamp, visibilityLevel, epoch, writeSet, conflictFreeWriteSet, tm);
     }
 
-    private void cleanCell(HBaseCellId cell) {
+    private void deleteCell(HBaseCellId cell) {
         Delete delete = new Delete(cell.getRow());
         delete.deleteColumn(cell.getFamily(), cell.getQualifier(), cell.getTimestamp());
         try {
@@ -51,11 +51,11 @@ public class HBaseTransaction extends AbstractTransaction<HBaseCellId> {
     @Override
     public void cleanup() {
         for (final HBaseCellId cell : getWriteSet()) {
-            cleanCell(cell);
+            deleteCell(cell);
         }
 
         for (final HBaseCellId cell : getConflictFreeWriteSet()) {
-            cleanCell(cell);
+            deleteCell(cell);
         }
         try {
             flushTables();

--- a/hbase-client/src/main/java/org/apache/omid/transaction/HBaseTransactionManager.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/HBaseTransactionManager.java
@@ -53,7 +53,7 @@ public class HBaseTransactionManager extends AbstractTransactionManager implemen
         @Override
         public HBaseTransaction createTransaction(long transactionId, long epoch, AbstractTransactionManager tm) {
 
-            return new HBaseTransaction(transactionId, epoch, new HashSet<HBaseCellId>(), tm);
+            return new HBaseTransaction(transactionId, epoch, new HashSet<HBaseCellId>(), new HashSet<HBaseCellId>(), tm);
 
         }
 

--- a/hbase-client/src/main/java/org/apache/omid/transaction/TTable.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/TTable.java
@@ -293,6 +293,10 @@ public class TTable implements Closeable {
 
     }
 
+    public void markPutAsConflictFreeMutation(Put put) {
+        put.setAttribute(CellUtils.CONFLICT_FREE_MUTATION, Bytes.toBytes(true));
+    }
+
     /**
      * Transactional version of {@link HTableInterface#put(Put put)}
      *
@@ -321,12 +325,23 @@ public class TTable implements Closeable {
                 Bytes.putLong(kv.getValueArray(), kv.getTimestampOffset(), writeTimestamp);
                 tsput.add(kv);
 
-                transaction.addWriteSetElement(
-                    new HBaseCellId(table,
-                                    CellUtil.cloneRow(kv),
-                                    CellUtil.cloneFamily(kv),
-                                    CellUtil.cloneQualifier(kv),
-                                    kv.getTimestamp()));
+                 byte[] conflictFree = put.getAttribute(CellUtils.CONFLICT_FREE_MUTATION);
+
+                 if (conflictFree != null && conflictFree[0]!=0) {
+                     transaction.addConflictFreeWriteSetElement(
+                             new HBaseCellId(table,
+                                     CellUtil.cloneRow(kv),
+                                     CellUtil.cloneFamily(kv),
+                                     CellUtil.cloneQualifier(kv),
+                                     kv.getTimestamp()));
+                 } else {
+                     transaction.addWriteSetElement(
+                             new HBaseCellId(table,
+                                     CellUtil.cloneRow(kv),
+                                     CellUtil.cloneFamily(kv),
+                                     CellUtil.cloneQualifier(kv),
+                                     kv.getTimestamp()));
+                 }
             }
         }
 

--- a/hbase-common/src/main/java/org/apache/omid/transaction/CellUtils.java
+++ b/hbase-common/src/main/java/org/apache/omid/transaction/CellUtils.java
@@ -52,6 +52,7 @@ public final class CellUtils {
     public static final byte[] FAMILY_DELETE_QUALIFIER = new byte[0];
     public static final String TRANSACTION_ATTRIBUTE = "__OMID_TRANSACTION__";
     public static final String CLIENT_GET_ATTRIBUTE = "__OMID_CLIENT_GET__";
+    public static final String CONFLICT_FREE_MUTATION = "__OMID_CONFLICT_FREE_MUTATION__";
 
     /**
      * Utility interface to get rid of the dependency on HBase server package

--- a/hbase-coprocessor/src/main/java/org/apache/omid/transaction/OmidSnapshotFilter.java
+++ b/hbase-coprocessor/src/main/java/org/apache/omid/transaction/OmidSnapshotFilter.java
@@ -111,7 +111,7 @@ public class OmidSnapshotFilter extends BaseRegionObserver {
             long epoch = transaction.getEpoch();
             VisibilityLevel visibilityLevel = VisibilityLevel.fromInteger(transaction.getVisibilityLevel());
 
-            HBaseTransaction hbaseTransaction = new HBaseTransaction(id, readTs, visibilityLevel, epoch, new HashSet<HBaseCellId>(), null);
+            HBaseTransaction hbaseTransaction = new HBaseTransaction(id, readTs, visibilityLevel, epoch, new HashSet<HBaseCellId>(), new HashSet<HBaseCellId>(), null);
             filteredKeyValues = snapshotFilter.filterCellsForSnapshot(res.listCells(), hbaseTransaction, get.getMaxVersions(), new HashMap<String, List<Cell>>());
         }
 
@@ -140,7 +140,7 @@ public class OmidSnapshotFilter extends BaseRegionObserver {
         long epoch = transaction.getEpoch();
         VisibilityLevel visibilityLevel = VisibilityLevel.fromInteger(transaction.getVisibilityLevel());
 
-        HBaseTransaction hbaseTransaction = new HBaseTransaction(id, readTs, visibilityLevel, epoch, new HashSet<HBaseCellId>(), null);
+        HBaseTransaction hbaseTransaction = new HBaseTransaction(id, readTs, visibilityLevel, epoch, new HashSet<HBaseCellId>(), new HashSet<HBaseCellId>(), null);
 
         RegionAccessWrapper regionAccessWrapper = new RegionAccessWrapper(HBaseShims.getRegionCoprocessorRegion(e.getEnvironment()));
 


### PR DESCRIPTION
… in conflict analysis. The purpose of this feature is to let the user decide for each write, whether it should take part in the conflict analysis.

The motivation infers from Apache Phoenix that utilizes this feature when writing to the secondary index and also when writing to the data table for immutable tables (each key is added once and is not modified).