### PR TITLE
[OMID-85] Writing directly to HBase using specific version marks the …

### DIFF
--- a/hbase-client/src/test/java/org/apache/omid/transaction/TestBasicTransaction.java
+++ b/hbase-client/src/test/java/org/apache/omid/transaction/TestBasicTransaction.java
@@ -466,7 +466,7 @@ public class TestBasicTransaction extends OmidTestBase {
 
         row1 = new Put(rowName1);
         row1.add(famName1, colName1, dataValue1);
-        tt.putWithAutocommit(tx2, row1);
+        tt.put(tx2, row1, true);
 
         r = tt.get(tx3, g);
         assertEquals(r.size(), 1, "Unexpected size for read.");

--- a/hbase-client/src/test/java/org/apache/omid/transaction/TestBasicTransaction.java
+++ b/hbase-client/src/test/java/org/apache/omid/transaction/TestBasicTransaction.java
@@ -437,4 +437,41 @@ public class TestBasicTransaction extends OmidTestBase {
 
     }
 
+    @Test(timeOut = 30_000)
+    public void testAutoCommit(ITestContext context)
+            throws Exception {
+
+        TransactionManager tm = newTransactionManager(context);
+        TTable tt = new TTable(hbaseConf, TEST_TABLE);
+
+        byte[] rowName1 = Bytes.toBytes("row1");
+        byte[] famName1 = Bytes.toBytes(TEST_FAMILY);
+        byte[] colName1 = Bytes.toBytes("col1");
+        byte[] dataValue1 = Bytes.toBytes("testWrite-1");
+
+        Transaction tx1 = tm.begin();
+
+        Put row1 = new Put(rowName1);
+        row1.add(famName1, colName1, dataValue1);
+        tt.put(tx1, row1);
+
+        Transaction tx2 = tm.begin();
+
+        Transaction tx3 = tm.begin();
+
+        Get g = new Get(rowName1).setMaxVersions();
+        g.addColumn(famName1, colName1);
+        Result r = tt.get(tx3, g);
+        assertEquals(r.size(), 0, "Unexpected size for read.");
+
+        row1 = new Put(rowName1);
+        row1.add(famName1, colName1, dataValue1);
+        tt.putWithAutocommit(tx2, row1);
+
+        r = tt.get(tx3, g);
+        assertEquals(r.size(), 1, "Unexpected size for read.");
+
+        tt.close();
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Java Version -->
-        <java.version>1.8</java.version>
+        <java.version>1.7</java.version>
 
         <!-- 3rd-Party Library Versioning -->
         <hbase0.version>0.98.10.1-hadoop1</hbase0.version>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Java Version -->
-        <java.version>1.7</java.version>
+        <java.version>1.8</java.version>
 
         <!-- 3rd-Party Library Versioning -->
         <hbase0.version>0.98.10.1-hadoop1</hbase0.version>


### PR DESCRIPTION
…write as a write that was done by a specific transaction.

However, due to lack of shadow cells, getting the commit timestamp of the transaction can be done only by access the commit table.
The motivation of this feature is to add the shadow cells during the write and save the commit table access.
This feature is required by Apache Phoenix that during index creation adds the data table's entries,
appeared before creation, to the index. In this case, the version and the commit timestamp should be the fence id and therefore, a direct write to HBase with the addition of shadow cells is required.