### PR TITLE
A bug fix in [OMID-74].

### DIFF
--- a/hbase-client/src/main/java/org/apache/omid/transaction/HBaseTransactionManager.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/HBaseTransactionManager.java
@@ -229,6 +229,10 @@ public class HBaseTransactionManager extends AbstractTransactionManager implemen
 
     }
 
+    public void setConflictDetectionLevel(ConflictDetectionLevel conflictDetectionLevel) {
+        tsoClient.setConflictDetectionLevel(conflictDetectionLevel);
+    }
+
     public ConflictDetectionLevel getConflictDetectionLevel() {
         return tsoClient.getConflictDetectionLevel();
     }

--- a/hbase-client/src/main/java/org/apache/omid/transaction/TTable.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/TTable.java
@@ -208,6 +208,8 @@ public class TTable implements Closeable {
                 }
                 deleteP.add(family, CellUtils.FAMILY_DELETE_QUALIFIER, tx.getWriteTimestamp(),
                         HConstants.EMPTY_BYTE_ARRAY);
+                tx.addWriteSetElement(new HBaseCellId(table, deleteP.getRow(), family, CellUtils.FAMILY_DELETE_QUALIFIER,
+                                                tx.getWriteTimestamp()));
             }
         }
     }
@@ -218,9 +220,10 @@ public class TTable implements Closeable {
         for (byte[] family : fset) {
             deleteP.add(family, CellUtils.FAMILY_DELETE_QUALIFIER, tx.getWriteTimestamp(),
                     HConstants.EMPTY_BYTE_ARRAY);
+            tx.addWriteSetElement(new HBaseCellId(table, deleteP.getRow(), family, CellUtils.FAMILY_DELETE_QUALIFIER,
+                    tx.getWriteTimestamp()));
+
         }
-        tx.addWriteSetElement(new HBaseCellId(table, deleteP.getRow(), null, null,
-                tx.getWriteTimestamp()));
     }
 
     /**

--- a/transaction-client/src/main/java/org/apache/omid/tso/client/TSOClient.java
+++ b/transaction-client/src/main/java/org/apache/omid/tso/client/TSOClient.java
@@ -307,6 +307,13 @@ public class TSOClient implements TSOProtocol, NodeCacheListener {
         return conflictDetectionLevel;
     }
 
+    /**
+     * Used for family deletion testing
+     */
+    public void setConflictDetectionLevel(ConflictDetectionLevel conflictDetectionLevel) {
+        this.conflictDetectionLevel = conflictDetectionLevel;
+    }
+
     // ----------------------------------------------------------------------------------------------------------------
     // NodeCacheListener interface
     // ----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The update of the write set is incorrect since the family deletion qualifier needs to be added instead of a row marker. Therefore, this commit fixes this case.
This is crucial since the write set information is needed for adding shadow cells, when transaction successfully commits, and for garbage collection when transaction aborts.