### PR TITLE
[OMID-72] bug fix, accessed tables should be sent to transaction mana…

### DIFF
--- a/hbase-client/src/test/java/org/apache/omid/transaction/TestHBaseTransactionManager.java
+++ b/hbase-client/src/test/java/org/apache/omid/transaction/TestHBaseTransactionManager.java
@@ -83,7 +83,7 @@ public class TestHBaseTransactionManager extends OmidTestBase {
             txTable.put(tx1, put);
             tm.commit(tx1);
 
-            verify(tsoClient, times(EXPECTED_INVOCATIONS_FOR_COMMIT)).commit(anyLong(), anySetOf(HBaseCellId.class));
+            verify(tsoClient, times(EXPECTED_INVOCATIONS_FOR_COMMIT)).commit(anyLong(), anySetOf(HBaseCellId.class), anySetOf(HBaseCellId.class));
 
             // Create a read-only tx and verify that commit has not been invoked again in the TSOClient
             AbstractTransaction readOnlyTx = (AbstractTransaction) tm.begin();
@@ -93,7 +93,7 @@ public class TestHBaseTransactionManager extends OmidTestBase {
             assertTrue(readOnlyTx.getWriteSet().isEmpty());
             tm.commit(readOnlyTx);
 
-            verify(tsoClient, times(EXPECTED_INVOCATIONS_FOR_COMMIT)).commit(anyLong(), anySetOf(HBaseCellId.class));
+            verify(tsoClient, times(EXPECTED_INVOCATIONS_FOR_COMMIT)).commit(anyLong(), anySetOf(HBaseCellId.class), anySetOf(HBaseCellId.class));
             assertEquals(readOnlyTx.getStatus(), Transaction.Status.COMMITTED_RO);
         }
 

--- a/hbase-client/src/test/java/org/apache/omid/transaction/TestTransactionCleanup.java
+++ b/hbase-client/src/test/java/org/apache/omid/transaction/TestTransactionCleanup.java
@@ -77,7 +77,7 @@ public class TestTransactionCleanup extends OmidTestBase {
                 .when(mockedTSOClient).getNewStartTimestamp();
 
         doReturn(abortingFF)
-                .when(mockedTSOClient).commit(eq(START_TS), anySetOf(HBaseCellId.class));
+                .when(mockedTSOClient).commit(eq(START_TS), anySetOf(HBaseCellId.class), anySetOf(HBaseCellId.class));
 
         try (TransactionManager tm = newTransactionManager(context, mockedTSOClient);
              TTable txTable = new TTable(hbaseConf, TEST_TABLE)) {

--- a/transaction-client/src/main/java/org/apache/omid/transaction/AbstractTransactionManager.java
+++ b/transaction-client/src/main/java/org/apache/omid/transaction/AbstractTransactionManager.java
@@ -359,7 +359,7 @@ public abstract class AbstractTransactionManager implements TransactionManager {
 
         try {
 
-            long commitTs = tsoClient.commit(tx.getStartTimestamp(), tx.getWriteSet()).get();
+            long commitTs = tsoClient.commit(tx.getStartTimestamp(), tx.getWriteSet(), tx.getConflictFreeWriteSet()).get();
             certifyCommitForTx(tx, commitTs);
             updateShadowCellsAndRemoveCommitTableEntry(tx, postCommitter);
 

--- a/transaction-client/src/main/java/org/apache/omid/tso/client/MockTSOClient.java
+++ b/transaction-client/src/main/java/org/apache/omid/tso/client/MockTSOClient.java
@@ -103,6 +103,11 @@ class MockTSOClient implements TSOProtocol {
     }
 
     @Override
+    public TSOFuture<Long> commit(long transactionId, Set<? extends CellId> cells, Set<? extends CellId> conflictFreeWriteSet) {
+        return commit(transactionId, cells);
+    }
+
+    @Override
     public TSOFuture<Long> commit(long transactionId, Set<? extends CellId> cells) {
         synchronized (conflictMap) {
             SettableFuture<Long> f = SettableFuture.create();

--- a/transaction-client/src/main/java/org/apache/omid/tso/client/TSOClient.java
+++ b/transaction-client/src/main/java/org/apache/omid/tso/client/TSOClient.java
@@ -201,6 +201,14 @@ public class TSOClient implements TSOProtocol, NodeCacheListener {
      */
     @Override
     public TSOFuture<Long> commit(long transactionId, Set<? extends CellId> cells) {
+        return commit(transactionId, cells, new HashSet<CellId>());
+    }
+
+    /**
+     * @see TSOProtocol#commit(long, Set, Set)
+     */
+    @Override
+    public TSOFuture<Long> commit(long transactionId, Set<? extends CellId> cells, Set<? extends CellId> conflictFreeWriteSet) {
         TSOProto.Request.Builder builder = TSOProto.Request.newBuilder();
         TSOProto.CommitRequest.Builder commitbuilder = TSOProto.CommitRequest.newBuilder();
         commitbuilder.setStartTimestamp(transactionId);
@@ -229,6 +237,11 @@ public class TSOClient implements TSOProtocol, NodeCacheListener {
             commitbuilder.addCellId(id);
             tableIDs.add(cell.getTableId());
         }
+
+        for (CellId cell : conflictFreeWriteSet) {
+            tableIDs.add(cell.getTableId());
+        }
+
         commitbuilder.addAllTableId(tableIDs);
         tableIDs.clear();
         builder.setCommitRequest(commitbuilder.build());

--- a/transaction-client/src/main/java/org/apache/omid/tso/client/TSOProtocol.java
+++ b/transaction-client/src/main/java/org/apache/omid/tso/client/TSOProtocol.java
@@ -51,6 +51,22 @@ public interface TSOProtocol {
     TSOFuture<Long> commit(long transactionId, Set<? extends CellId> writeSet);
 
     /**
+     * Returns the result of the conflict detection made on the server-side for the specified transaction
+     * @param transactionId
+     *          the transaction to check for conflicts
+     * @param writeSet
+     *          the writeSet of the transaction, which includes all the modified cells
+     * @param conflictFreeWriteSet
+     *          the conflict free writeSet of the transaction, needed only for table access information.
+     * @return the commit timestamp as a future if the transaction was committed. If the transaction was aborted due
+     * to conflicts with a concurrent transaction, the future will include an AbortException. If an error was detected,
+     * the future will contain a corresponding protocol exception
+     * see org.apache.omid.tso.TimestampOracle
+     * see org.apache.omid.tso.TSOServer
+     */
+    TSOFuture<Long> commit(long transactionId, Set<? extends CellId> writeSet, Set<? extends CellId> conflictFreeWriteSet);
+
+    /**
      * Returns a new fence timestamp assigned by on the server-side
      * @param tableId
      *          the table to create fence for.

--- a/transaction-client/src/test/java/org/apache/omid/tso/client/TestMockTSOClient.java
+++ b/transaction-client/src/test/java/org/apache/omid/tso/client/TestMockTSOClient.java
@@ -18,11 +18,13 @@
 package org.apache.omid.tso.client;
 
 import com.google.common.collect.Sets;
+
 import org.apache.omid.committable.CommitTable;
 import org.apache.omid.committable.InMemoryCommitTable;
 import org.apache.omid.tso.util.DummyCellIdImpl;
 import org.testng.annotations.Test;
 
+import java.util.HashSet;
 import java.util.concurrent.ExecutionException;
 
 import static org.testng.Assert.assertEquals;
@@ -42,10 +44,10 @@ public class TestMockTSOClient {
         long tr1 = client.getNewStartTimestamp().get();
         long tr2 = client.getNewStartTimestamp().get();
 
-        client.commit(tr1, Sets.newHashSet(c1), null).get();
+        client.commit(tr1, Sets.newHashSet(c1), new HashSet<CellId>()).get();
 
         try {
-            client.commit(tr2, Sets.newHashSet(c1, c2), null).get();
+            client.commit(tr2, Sets.newHashSet(c1, c2), new HashSet<CellId>()).get();
             fail("Shouldn't have committed");
         } catch (ExecutionException ee) {
             assertEquals(ee.getCause().getClass(), AbortException.class, "Should have aborted");
@@ -59,12 +61,12 @@ public class TestMockTSOClient {
         CommitTable.Client commitTableClient = commitTable.getClient();
 
         long tr1 = client.getNewStartTimestamp().get();
-        client.commit(tr1, Sets.newHashSet(c1), null).get();
+        client.commit(tr1, Sets.newHashSet(c1), new HashSet<CellId>()).get();
 
         long initWatermark = commitTableClient.readLowWatermark().get();
 
         long tr2 = client.getNewStartTimestamp().get();
-        client.commit(tr2, Sets.newHashSet(c1), null).get();
+        client.commit(tr2, Sets.newHashSet(c1), new HashSet<CellId>()).get();
 
         long newWatermark = commitTableClient.readLowWatermark().get();
         assertTrue(newWatermark > initWatermark, "new low watermark should be bigger");

--- a/transaction-client/src/test/java/org/apache/omid/tso/client/TestMockTSOClient.java
+++ b/transaction-client/src/test/java/org/apache/omid/tso/client/TestMockTSOClient.java
@@ -42,10 +42,10 @@ public class TestMockTSOClient {
         long tr1 = client.getNewStartTimestamp().get();
         long tr2 = client.getNewStartTimestamp().get();
 
-        client.commit(tr1, Sets.newHashSet(c1)).get();
+        client.commit(tr1, Sets.newHashSet(c1), null).get();
 
         try {
-            client.commit(tr2, Sets.newHashSet(c1, c2)).get();
+            client.commit(tr2, Sets.newHashSet(c1, c2), null).get();
             fail("Shouldn't have committed");
         } catch (ExecutionException ee) {
             assertEquals(ee.getCause().getClass(), AbortException.class, "Should have aborted");
@@ -59,12 +59,12 @@ public class TestMockTSOClient {
         CommitTable.Client commitTableClient = commitTable.getClient();
 
         long tr1 = client.getNewStartTimestamp().get();
-        client.commit(tr1, Sets.newHashSet(c1)).get();
+        client.commit(tr1, Sets.newHashSet(c1), null).get();
 
         long initWatermark = commitTableClient.readLowWatermark().get();
 
         long tr2 = client.getNewStartTimestamp().get();
-        client.commit(tr2, Sets.newHashSet(c1)).get();
+        client.commit(tr2, Sets.newHashSet(c1), null).get();
 
         long newWatermark = commitTableClient.readLowWatermark().get();
         assertTrue(newWatermark > initWatermark, "new low watermark should be bigger");


### PR DESCRIPTION
…ger also for conflict free writes. This is because fences should also force conflict free transactions to abort.