### PR TITLE
[OMID-105] When a tentative family deletion marker is found. We need …

### DIFF
--- a/hbase-client/src/main/java/org/apache/omid/transaction/AttributeSetSnapshotFilter.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/AttributeSetSnapshotFilter.java
@@ -65,7 +65,7 @@ public class AttributeSetSnapshotFilter implements SnapshotFilter {
 
     @Override
     public List<Cell> filterCellsForSnapshot(List<Cell> rawCells, HBaseTransaction transaction,
-                                      int versionsToRequest, Map<String, List<Cell>> familyDeletionCache, Map<String,byte[]> attributeMap) throws IOException {
+                                      int versionsToRequest, Map<String, Long> familyDeletionCache, Map<String,byte[]> attributeMap) throws IOException {
         throw new UnsupportedOperationException();
     }
 

--- a/hbase-client/src/main/java/org/apache/omid/transaction/SnapshotFilter.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/SnapshotFilter.java
@@ -37,7 +37,7 @@ public interface SnapshotFilter {
     public ResultScanner getScanner(TTable ttable, Scan scan, HBaseTransaction transaction) throws IOException;
 
     public List<Cell> filterCellsForSnapshot(List<Cell> rawCells, HBaseTransaction transaction,
-            int versionsToRequest, Map<String, List<Cell>> familyDeletionCache, Map<String,byte[]> attributeMap) throws IOException;
+            int versionsToRequest, Map<String, Long> familyDeletionCache, Map<String,byte[]> attributeMap) throws IOException;
 
     public boolean isCommitted(HBaseCellId hBaseCellId, long epoch) throws TransactionException;
 

--- a/hbase-client/src/main/java/org/apache/omid/transaction/SnapshotFilterImpl.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/SnapshotFilterImpl.java
@@ -303,10 +303,10 @@ public class SnapshotFilterImpl implements SnapshotFilter {
                 if (familyDeletionCache.containsKey(key))
                     return;
 
-                Optional<Long> commitTimeStamp = getTSIfInSnapshot(cell, transaction, commitCache);
+                Optional<Long> commitTimeStamp = getTSIfInTransaction(cell, transaction, commitCache);
 
                 if (!commitTimeStamp.isPresent()) {
-                    commitTimeStamp = getTSIfInTransaction(cell, transaction, commitCache);
+                    commitTimeStamp = getTSIfInSnapshot(cell, transaction, commitCache);
                 }
 
                 if (commitTimeStamp.isPresent()) {
@@ -314,13 +314,10 @@ public class SnapshotFilterImpl implements SnapshotFilter {
                 } else {
                     Cell lastCell = cell;
                     Map<Long, Long> cmtCache;
-                    boolean foundCommitttedFamilyDeletion = false;
-                    while (!foundCommitttedFamilyDeletion) {
+                    boolean foundCommittedFamilyDeletion = false;
+                    while (!foundCommittedFamilyDeletion) {
 
                         Get g = createPendingGet(lastCell, 3);
-                        for (Map.Entry<String,byte[]> entry : attributeMap.entrySet()) {
-                            g.setAttribute(entry.getKey(), entry.getValue());
-                        }
 
                         Result result = tableAccessWrapper.get(g);
                         List<Cell> resultCells = result.listCells();
@@ -334,7 +331,7 @@ public class SnapshotFilterImpl implements SnapshotFilter {
                                     commitTimeStamp = getTSIfInSnapshot(c, transaction, cmtCache);
                                     if (commitTimeStamp.isPresent()) {
                                         familyDeletionCache.put(key, commitTimeStamp.get());
-                                        foundCommitttedFamilyDeletion = true;
+                                        foundCommittedFamilyDeletion = true;
                                         break;
                                     }
                                     lastCell = c;

--- a/hbase-client/src/main/java/org/apache/omid/transaction/TTable.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/TTable.java
@@ -447,7 +447,7 @@ public class TTable implements Closeable {
 
 
     List<Cell> filterCellsForSnapshot(List<Cell> rawCells, HBaseTransaction transaction,
-                                      int versionsToRequest, Map<String, List<Cell>> familyDeletionCache, Map<String,byte[]> attributeMap) throws IOException {
+                                      int versionsToRequest, Map<String, Long> familyDeletionCache, Map<String,byte[]> attributeMap) throws IOException {
         return snapshotFilter.filterCellsForSnapshot(rawCells, transaction, versionsToRequest, familyDeletionCache, attributeMap);
     }
 
@@ -457,7 +457,7 @@ public class TTable implements Closeable {
         private HBaseTransaction state;
         private ResultScanner innerScanner;
         private int maxVersions;
-        Map<String, List<Cell>> familyDeletionCache;
+        Map<String, Long> familyDeletionCache;
         private Map<String,byte[]> attributeMap;
 
         TransactionalClientScanner(HBaseTransaction state, Scan scan, int maxVersions)
@@ -465,7 +465,7 @@ public class TTable implements Closeable {
             this.state = state;
             this.innerScanner = table.getScanner(scan);
             this.maxVersions = maxVersions;
-            this.familyDeletionCache = new HashMap<String, List<Cell>>();
+            this.familyDeletionCache = new HashMap<String, Long>();
             this.attributeMap = scan.getAttributesMap();
         }
 

--- a/hbase-client/src/test/java/org/apache/omid/transaction/TestShadowCells.java
+++ b/hbase-client/src/test/java/org/apache/omid/transaction/TestShadowCells.java
@@ -346,7 +346,7 @@ public class TestShadowCells extends OmidTestBase {
                             return (List<KeyValue>) invocation.callRealMethod();
                         }
                     }).when(table).filterCellsForSnapshot(Matchers.<List<Cell>>any(),
-                            any(HBaseTransaction.class), anyInt(), Matchers.<Map<String, List<Cell>>>any(), Matchers.<Map<String,byte[]>>any());
+                            any(HBaseTransaction.class), anyInt(), Matchers.<Map<String, Long>>any(), Matchers.<Map<String,byte[]>>any());
 
                     TransactionManager tm = newTransactionManager(context);
                     if (hasShadowCell(row,

--- a/hbase-common/src/main/java/org/apache/omid/transaction/CellUtils.java
+++ b/hbase-common/src/main/java/org/apache/omid/transaction/CellUtils.java
@@ -24,6 +24,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
+
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellComparator;
 import org.apache.hadoop.hbase.CellUtil;
@@ -233,6 +234,16 @@ public final class CellUtils {
      */
     public static boolean isTombstone(Cell cell) {
         return CellUtil.matchingValue(cell, DELETE_TOMBSTONE);
+    }
+
+    /**
+     * Returns if a cell is a family deletion marker.
+     * @param cell the cell to check
+     * @return whether the cell is marked as a family deletion marker
+     */
+    public static boolean isFamilyDeleteCell(Cell cell) {
+        return CellUtil.matchingQualifier(cell, CellUtils.FAMILY_DELETE_QUALIFIER) &&
+                CellUtil.matchingValue(cell, HConstants.EMPTY_BYTE_ARRAY);
     }
 
     /**

--- a/hbase-coprocessor/src/main/java/org/apache/hadoop/hbase/regionserver/OmidRegionScanner.java
+++ b/hbase-coprocessor/src/main/java/org/apache/hadoop/hbase/regionserver/OmidRegionScanner.java
@@ -37,7 +37,7 @@ public class OmidRegionScanner implements RegionScanner {
     private SnapshotFilterImpl snapshotFilter;
     private HBaseTransaction transaction;
     private int maxVersions;
-    private Map<String, List<Cell>> familyDeletionCache;
+    private Map<String, Long> familyDeletionCache;
     private Map<String,byte[]> attributeMap;
 
     public OmidRegionScanner(SnapshotFilterImpl snapshotFilter,
@@ -49,7 +49,7 @@ public class OmidRegionScanner implements RegionScanner {
         this.scanner = s;
         this.transaction = transaction;
         this.maxVersions = maxVersions;
-        this.familyDeletionCache = new HashMap<String, List<Cell>>();
+        this.familyDeletionCache = new HashMap<String, Long>();
         this.attributeMap = attributeMap;
     }
 

--- a/hbase-coprocessor/src/main/java/org/apache/omid/transaction/OmidSnapshotFilter.java
+++ b/hbase-coprocessor/src/main/java/org/apache/omid/transaction/OmidSnapshotFilter.java
@@ -126,7 +126,7 @@ public class OmidSnapshotFilter extends BaseRegionObserver {
 
 
                 HBaseTransaction hbaseTransaction = new HBaseTransaction(id, readTs, visibilityLevel, epoch, new HashSet<HBaseCellId>(), new HashSet<HBaseCellId>(), null);
-                filteredKeyValues = snapshotFilter.filterCellsForSnapshot(res.listCells(), hbaseTransaction, get.getMaxVersions(), new HashMap<String, List<Cell>>(), get.getAttributesMap());
+                filteredKeyValues = snapshotFilter.filterCellsForSnapshot(res.listCells(), hbaseTransaction, get.getMaxVersions(), new HashMap<String, Long>(), get.getAttributesMap());
             }
 
             for (Cell cell : filteredKeyValues) {


### PR DESCRIPTION
…to continue looking until we either find a  committed one in the past or no committed family deletion marker for this column is found. Otherwise, we might miss committed family deletion markers that exists in a transaction snapshot.