### PR TITLE
[OMID-106] Delete should use write timestamp when writing family dele…

### DIFF
--- a/hbase-client/src/main/java/org/apache/omid/transaction/TTable.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/TTable.java
@@ -245,7 +245,7 @@ public class TTable implements Closeable {
 
         HBaseTransaction transaction = enforceHBaseTransactionAsParam(tx);
 
-        final long writeTimestamp = transaction.getStartTimestamp();
+        final long writeTimestamp = transaction.getWriteTimestamp();
         boolean deleteFamily = false;
 
         final Put deleteP = new Put(delete.getRow(), writeTimestamp);


### PR DESCRIPTION
…tion marker. This is noticeable after a checkpoint.